### PR TITLE
golang: Use a non-blocking send in broadcast

### DIFF
--- a/go/src/hashrocket/go-websocket-server/handler.go
+++ b/go/src/hashrocket/go-websocket-server/handler.go
@@ -71,6 +71,7 @@ func (h *benchHandler) echo(ws *websocket.Conn, payload interface{}) error {
 
 func (h *benchHandler) broadcast(ws *websocket.Conn, payload interface{}) error {
 	result := BroadcastResult{Type: "broadcastResult", Payload: payload}
+	request := &WsMsg{Type: "broadcast", Payload: payload}
 
 	wg := sync.WaitGroup{}
 	var count int64
@@ -79,7 +80,7 @@ func (h *benchHandler) broadcast(ws *websocket.Conn, payload interface{}) error 
 	for c := range h.conns {
 		wg.Add(1)
 		go func(ws *websocket.Conn) {
-			if err := websocket.JSON.Send(ws, &WsMsg{Type: "broadcast", Payload: payload}); err == nil {
+			if err := websocket.JSON.Send(ws, request); err == nil {
 				atomic.AddInt64(&count, 1)
 			}
 			wg.Done()

--- a/go/src/hashrocket/websocket-bench/main.go
+++ b/go/src/hashrocket/websocket-bench/main.go
@@ -117,10 +117,6 @@ func Stress(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		if options.limitRTT < rttAgg.Percentile(options.limitPercentile) {
-			return
-		}
-
 		fmt.Printf("clients: %5d    %dper-rtt: %3dms    min-rtt: %3dms    median-rtt: %3dms    max-rtt: %3dms\n",
 			clientCount,
 			options.limitPercentile,
@@ -128,6 +124,10 @@ func Stress(cmd *cobra.Command, args []string) {
 			roundToMS(rttAgg.Min()),
 			roundToMS(rttAgg.Percentile(50)),
 			roundToMS(rttAgg.Max()))
+
+		if options.limitRTT < rttAgg.Percentile(options.limitPercentile) {
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Note: This seems to actually make it slower! Do not merge in, sending in as another datapoint.

This should help improve the performance of go in the benchmark. The only "ugly"
pattern this introduces is using an atomic int increment, but this ends up
simpler and more performant than the alternatives.

Benchmark on localhost:

```
./websocket-bench broadcast ws://127.0.0.1:3000/ws --concurrent 10 --sample-size 100 --step-size 500 --limit-percentile 95 --limit-rtt 500ms

# Before
clients:   500    95per-rtt: 137ms    min-rtt:   9ms    median-rtt:  50ms    max-rtt: 185ms
clients:  1000    95per-rtt: 188ms    min-rtt:  22ms    median-rtt: 110ms    max-rtt: 387ms
clients:  1500    95per-rtt: 375ms    min-rtt:  35ms    median-rtt: 152ms    max-rtt: 607ms
clients:  2000    95per-rtt: 443ms    min-rtt:  51ms    median-rtt: 210ms    max-rtt: 674ms
clients:  2500    95per-rtt: 584ms    min-rtt:  72ms    median-rtt: 284ms    max-rtt: 915ms

# Before less allocations
clients:   500    95per-rtt: 102ms    min-rtt:  15ms    median-rtt:  52ms    max-rtt: 178ms
clients:  1000    95per-rtt: 274ms    min-rtt:  21ms    median-rtt: 102ms    max-rtt: 366ms
clients:  1500    95per-rtt: 308ms    min-rtt:  40ms    median-rtt: 148ms    max-rtt: 790ms
clients:  2000    95per-rtt: 440ms    min-rtt:  29ms    median-rtt: 195ms    max-rtt: 657ms
clients:  2500    95per-rtt: 619ms    min-rtt:  41ms    median-rtt: 258ms    max-rtt: 801ms

# After
clients:   500    95per-rtt: 134ms    min-rtt:  18ms    median-rtt:  75ms    max-rtt: 176ms
clients:  1000    95per-rtt: 285ms    min-rtt:  12ms    median-rtt: 141ms    max-rtt: 331ms
clients:  1500    95per-rtt: 485ms    min-rtt:  29ms    median-rtt: 215ms    max-rtt: 730ms
clients:  2000    95per-rtt: 678ms    min-rtt:  29ms    median-rtt: 330ms    max-rtt: 842ms

# After less allocations
clients:   500    95per-rtt: 165ms    min-rtt:   5ms    median-rtt:  70ms    max-rtt: 210ms
clients:  1000    95per-rtt: 266ms    min-rtt:  38ms    median-rtt: 153ms    max-rtt: 330ms
clients:  1500    95per-rtt: 375ms    min-rtt:  59ms    median-rtt: 248ms    max-rtt: 430ms
clients:  2000    95per-rtt: 517ms    min-rtt:  88ms    median-rtt: 285ms    max-rtt: 831ms
```
