### PR TITLE
clojure: small optimizations

### DIFF
--- a/clojure/httpkit/src/websocket/main.clj
+++ b/clojure/httpkit/src/websocket/main.clj
@@ -13,7 +13,7 @@
   (Integer/parseInt (or port (env :port) "3000")))
 
 (defn start-server [port]
-  (reset! server (http-kit/run-server app {:port port})))
+  (reset! server (http-kit/run-server app {:port port :thread 32})))
 
 (defn stop-server []
   (when @server

--- a/clojure/httpkit/src/websocket/server.clj
+++ b/clojure/httpkit/src/websocket/server.clj
@@ -16,8 +16,9 @@
   (swap! channels disj channel))
 
 (defn broadcast [ch payload]
-  (doseq [channel @channels]
-    (send! channel (json/encode {:type "broadcast" :payload payload})))
+  (let [msg (json/encode {:type "broadcast" :payload payload})]
+    (doseq [channel @channels]
+      (send! channel msg)))
   (send! ch (json/encode {:type "broadcastResult" :payload payload})))
 
 (defn echo [ch payload]


### PR DESCRIPTION
Thanks for doing this comparison!

Here are a couple of small changes for the clojure server, which may or may not help its performance.

1) Only JSON-encode the message once for broadcast, rather than each
time around the loop.

2) More server threads. httpkit defaults to only 4 threads. Using more
might not make any difference, since it's async I/O, but since it's easy
to do, I thought it would be worth a try.
