### PR TITLE
Enable direct linking in Clojure.

### DIFF
--- a/clojure/httpkit/README.md
+++ b/clojure/httpkit/README.md
@@ -11,6 +11,7 @@ To build the server:
     which java # ensure you have java installed
     which boot # ensure you have boot installed
     boot -u    # keep boot up-to-date
+    export BOOT_JVM_OPTIONS=-Dclojure.compiler.direct-linking=true  # enable direct linking
     boot build # builds an uberjar to the build/ directory
 
 Then, to run the server:


### PR DESCRIPTION
Direct linking is a compiler feature that is particularly useful for
AOT-compiled server programs. It removes some of the dynamicity of
Clojure (late dereferencing via vars) in favor of direct static calls
in the compiled code. This generally results in JVM bytecode that is
more amenable to JIT optimization by the JVM.
