### PR TITLE
Add event machine

### DIFF
--- a/ruby/event-machine/Gemfile
+++ b/ruby/event-machine/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'em-websocket'

--- a/ruby/event-machine/Gemfile.lock
+++ b/ruby/event-machine/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.0.1)
+    http_parser.rb (0.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  em-websocket
+
+BUNDLED WITH
+   1.12.5

--- a/ruby/event-machine/server.rb
+++ b/ruby/event-machine/server.rb
@@ -11,7 +11,6 @@ EM.run {
     }
 
     ws.onmessage { |msg|
-      puts msg.inspect
       cmd, payload = JSON(msg).values_at('type', 'payload')
       if cmd == 'echo'
         ws.send payload.to_json

--- a/ruby/event-machine/server.rb
+++ b/ruby/event-machine/server.rb
@@ -1,0 +1,23 @@
+require 'em-websocket'
+require 'json'
+
+EM.run {
+  @channel = EM::Channel.new
+
+  EM::WebSocket.run(:host => "0.0.0.0", :port => 8080) do |ws|
+    ws.onopen {
+      sid = @channel.subscribe {|msg| ws.send msg }
+      @channel.push "#{sid} connected"
+    }
+
+    ws.onmessage { |msg|
+      puts msg.inspect
+      cmd, payload = JSON(msg).values_at('type', 'payload')
+      if cmd == 'echo'
+        ws.send payload.to_json
+      else
+        @channel.push payload.to_json
+      end
+    }
+  end
+}


### PR DESCRIPTION
It feels a bit unfair to compare framework-baked WebSocket solutions against language-level WebSocket libraries. For example, it might be worth writing a non-Phoenix version for Elixir as well?

I haven't used Go since I played with it for ~30 minutes when it was first announced, so I have no idea how to get the benchmarks to run.
