### PR TITLE
Clojure speedup

### DIFF
--- a/clojure/httpkit/README.md
+++ b/clojure/httpkit/README.md
@@ -16,7 +16,7 @@ To build the server:
 
 Then, to run the server:
 
-    java -server -XX:+AggressiveOpts -Xms2g -Xmx2g -jar build/app.jar # defaults to port 3000
+    java -server -XX:+AggressiveOpts -Xms8g -Xmx8g -jar build/app.jar # defaults to port 3000
 
 OR
 

--- a/clojure/httpkit/README.md
+++ b/clojure/httpkit/README.md
@@ -16,7 +16,7 @@ To build the server:
 
 Then, to run the server:
 
-    java -jar build/app.jar # defaults to port 3000
+    java -server -XX:+AggressiveOpts -Xms2g -Xmx2g -jar build/app.jar # defaults to port 3000
 
 OR
 

--- a/clojure/httpkit/README.md
+++ b/clojure/httpkit/README.md
@@ -16,7 +16,7 @@ To build the server:
 
 Then, to run the server:
 
-    java -server -XX:+AggressiveOpts -Xms8g -Xmx8g -jar build/app.jar # defaults to port 3000
+    java -server -XX:+AggressiveOpts -XX:+UseG1GC -XX:MaxGCPauseMillis=50 -Xms8g -Xmx8g -jar build/app.jar # defaults to port 3000
 
 OR
 

--- a/clojure/httpkit/boot.properties
+++ b/clojure/httpkit/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Sat Sep 03 15:10:38 BST 2016
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.8.0
+BOOT_VERSION=2.6.0

--- a/clojure/httpkit/build.boot
+++ b/clojure/httpkit/build.boot
@@ -5,7 +5,6 @@
                   [environ "1.1.0"]
                   [compojure "1.5.1"]
                   [cheshire  "5.6.3"]
-                  [ring/ring-defaults "0.2.1"]
                   [http-kit "2.2.0"]])
 
 (task-options!

--- a/clojure/httpkit/src/websocket/server.clj
+++ b/clojure/httpkit/src/websocket/server.clj
@@ -1,6 +1,5 @@
 (ns websocket.server
   (:require [compojure.core :refer [GET defroutes]]
-            [ring.middleware.defaults :refer [wrap-defaults api-defaults]]
             [clojure.tools.logging :as log]
             [cheshire.core :as json]
             [org.httpkit.server :refer [send! with-channel on-close on-receive]]))
@@ -38,9 +37,5 @@
     (on-close channel #(disconnect! channel %))
     (on-receive channel #(dispatch channel %))))
 
-(defroutes websocket-routes
+(defroutes app
   (GET "/ws" request (ws-handler request)))
-
-(def app
-  (wrap-defaults websocket-routes api-defaults))
-

--- a/clojure/httpkit/src/websocket/server.clj
+++ b/clojure/httpkit/src/websocket/server.clj
@@ -8,11 +8,9 @@
 (defonce channels (atom #{}))
 
 (defn connect! [channel]
-  (log/info "channel open")
   (swap! channels conj channel))
 
 (defn disconnect! [channel status]
-  (log/info "channel closed:" status)
   (swap! channels disj channel))
 
 (defn broadcast [ch payload]

--- a/clojure/httpkit/src/websocket/server.clj
+++ b/clojure/httpkit/src/websocket/server.clj
@@ -15,8 +15,7 @@
 
 (defn broadcast [ch payload]
   (let [msg (json/encode {:type "broadcast" :payload payload})]
-    (doseq [channel @channels]
-      (send! channel msg)))
+    (run! #(send! % msg) @channels))
   (send! ch (json/encode {:type "broadcastResult" :payload payload})))
 
 (defn echo [ch payload]

--- a/clojure/httpkit/src/websocket/server.clj
+++ b/clojure/httpkit/src/websocket/server.clj
@@ -35,7 +35,7 @@
 (defn ws-handler [request]
   (with-channel request channel
     (connect! channel)
-    (on-close channel (partial disconnect! channel))
+    (on-close channel #(disconnect! channel %))
     (on-receive channel #(dispatch channel %))))
 
 (defroutes websocket-routes


### PR DESCRIPTION
I'm opening this in the hope I (and maybe others) can learn a bit more about optimising a Clojure application. I have a little experience with this and can click around in YourKit, but there are definitely some more expert people out there who might be able to educate us all.

Some ideas I've been playing with to get a bit more bang for our buck:
1. Replace use of `partial` with an anonymous function
2. Avoid logging when not absolutely required
3. Remove overhead from ring-defaults
4. Make sure we're using Clojure 1.8.0 and not 1.7.0
5. Give the JVM loads of memory, and use G1GC with a low target GC time

I think the real win will come from proper GC tuning. I'm not sure exactly what options were used when running `java -jar build/app.jar` so maybe this won't help?

I've profiled this locally and it looks pretty good. GC pauses are down to less than 50 milliseconds, and most of the time is spent writing bytes via `sun.nio.ch.SocketChannelImpl.write(ByteBuffer[], int, int)`.

Unfortunately, I don't have two nice powerful Ubuntu machines to really test out these changes, so hope maybe someone from Hashrocket might do me a favour and run the benchmarks for me?
