### PR TITLE
use uws instead of ws package for node.js server

### DIFF
--- a/js/ws-bench/index.js
+++ b/js/ws-bench/index.js
@@ -1,4 +1,6 @@
-var WebSocketServer = require('ws').Server;
+'use strict';
+
+var WebSocketServer = require('uws').Server;
 var wss             = new WebSocketServer({ port: 3334 });
 
 function echo(ws, payload) {

--- a/js/ws-bench/package.json
+++ b/js/ws-bench/package.json
@@ -8,5 +8,7 @@
   },
   "author": "Jack Christensen & Jonathan Jackson",
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "uws": "^0.8.0"
+  }
 }


### PR DESCRIPTION
I would love to see the numbers benchmarked with uws. uws claims to be as much as 33x faster than `ws` package, so there should be significant speedup.
