### PR TITLE
golang: added go server that uses gorilla websockets framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "go/src/github.com/spf13/pflag"]
 	path = go/src/github.com/spf13/pflag
 	url = https://github.com/spf13/pflag.git
+[submodule "go/src/github.com/gorilla/websocket"]
+	path = go/src/github.com/gorilla/websocket
+	url = https://github.com/gorilla/websocket

--- a/go/src/hashrocket/go-gorilla-server/handler.go
+++ b/go/src/hashrocket/go-gorilla-server/handler.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type benchHandler struct {
+	mutex sync.RWMutex
+	conns map[*websocket.Conn]*connection
+}
+
+type connection struct {
+	sync.Mutex
+	ws *websocket.Conn
+}
+
+type WsMsg struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+type BroadcastResult struct {
+	Type          string      `json:"type"`
+	Payload       interface{} `json:"payload"`
+	ListenerCount int         `json:"listenerCount"`
+}
+
+func NewBenchHandler() *benchHandler {
+	return &benchHandler{
+		conns: make(map[*websocket.Conn]*connection),
+	}
+}
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  256,
+	WriteBufferSize: 256,
+}
+
+func (h *benchHandler) ServeHTTP(rsp http.ResponseWriter, req *http.Request) {
+	conn, err := upgrader.Upgrade(rsp, req, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	h.Accept(conn)
+}
+
+func (h *benchHandler) Accept(ws *websocket.Conn) {
+	defer h.cleanup(ws)
+
+	c := &connection{ws: ws}
+
+	h.mutex.Lock()
+	h.conns[ws] = c
+	h.mutex.Unlock()
+
+	for {
+		var msg WsMsg
+		err := websocket.ReadJSON(ws, &msg)
+		if err != nil && err.(*websocket.CloseError) != nil && err.(*websocket.CloseError).Code == websocket.CloseAbnormalClosure {
+			return
+		} else if err != nil {
+			log.Println("websocket.ReadJSON err:", err)
+			return
+		}
+
+		switch msg.Type {
+		case "echo":
+			if err := h.echo(c, msg.Payload); err != nil {
+				log.Println("echo err:", err)
+				return
+			}
+		case "broadcast":
+			if err := h.broadcast(c, msg.Payload); err != nil {
+				log.Println("broadcast err:", err)
+				return
+			}
+		default:
+			log.Println("unknown msg.Type")
+			return
+		}
+	}
+}
+
+func (h *benchHandler) echo(c *connection, payload interface{}) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.ws.WriteJSON(&WsMsg{Type: "echo", Payload: payload})
+}
+
+func (h *benchHandler) broadcast(c *connection, payload interface{}) error {
+	result := BroadcastResult{Type: "broadcastResult", Payload: payload}
+
+	msg, err := json.Marshal(&WsMsg{Type: "broadcast", Payload: payload})
+
+	if err != nil {
+		log.Println("broadcast json marshal err:", err)
+	} else {
+
+		h.mutex.RLock()
+
+		for _, c := range h.conns {
+			c.Lock()
+			if err := c.ws.WriteMessage(websocket.TextMessage, msg); err == nil {
+				result.ListenerCount++
+			}
+			c.Unlock()
+		}
+		h.mutex.RUnlock()
+	}
+
+	c.Lock()
+	defer c.Unlock()
+	return c.ws.WriteJSON(&result)
+}
+
+func (h *benchHandler) cleanup(ws *websocket.Conn) {
+	ws.Close()
+	h.mutex.Lock()
+
+	delete(h.conns, ws)
+
+	h.mutex.Unlock()
+}

--- a/go/src/hashrocket/go-gorilla-server/main.go
+++ b/go/src/hashrocket/go-gorilla-server/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+func main() {
+	var options struct {
+		address    string
+		port       int
+		cpuprofile bool
+		memprofile bool
+	}
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage:  %s [options]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.StringVar(&options.address, "address", "localhost", "address to listen on")
+	flag.IntVar(&options.port, "port", 3000, "port to listen on")
+	flag.BoolVar(&options.cpuprofile, "cpuprofile", false, "capture a cpu profile")
+	flag.BoolVar(&options.memprofile, "memprofile", false, "capture a memory profile")
+	flag.Parse()
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	if options.cpuprofile {
+		out := os.Args[0] + "-cpu.prof"
+		var f *os.File
+		f, err := os.Create(out)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Writing cpu profile to", out)
+		pprof.StartCPUProfile(f)
+		defer f.Close()
+		defer pprof.StopCPUProfile()
+	}
+
+	if options.memprofile {
+		out := os.Args[0] + "-mem.prof"
+		var f *os.File
+		f, err := os.Create(out)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Writing memory profile to", out)
+		pprof.WriteHeapProfile(f)
+		defer f.Close()
+	}
+
+	wsHandler := NewBenchHandler()
+	http.Handle("/ws", wsHandler)
+
+	listenAt := fmt.Sprintf("%s:%d", options.address, options.port)
+	log.Printf("Starting to listen on: %s\n", listenAt)
+
+	listener, err := net.Listen("tcp", listenAt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := http.Serve(listener, nil); err != nil && !strings.HasSuffix(err.Error(), "use of closed network connection") {
+			log.Println(err)
+		}
+	}()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	<-c
+	listener.Close()
+	wg.Wait()
+}


### PR DESCRIPTION
Adds a go server that uses gorilla websockets with the same general structure as the original go server.  Also added options to generate profiles with --cpuprofile and --memprofile.

Performance is a few percentage points better on my system (vs current master), memory consumption is about half (per the GC stats).
