### PR TITLE
Add several threaded implementations for Rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,8 +3,12 @@ name = "rust-ws-server"
 version = "0.1.0"
 dependencies = [
  "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mioco 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-pool 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -51,8 +55,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "context"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "dtoa"
 version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -116,6 +141,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mioco"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "context 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-scoped 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,8 +191,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -159,6 +228,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scoped-pool"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "variance 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scopeguard"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -187,6 +284,16 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "slab"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "spin"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "thread-scoped"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "threadpool"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
@@ -242,8 +359,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "variance"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,19 +2,19 @@
 name = "rust-ws-server"
 version = "0.1.0"
 dependencies = [
- "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mioco 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-pool 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -39,19 +39,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -259,7 +257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -270,7 +268,7 @@ dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -300,10 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "term_size"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ws"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,14 +2,25 @@
 name = "rust-ws-server"
 version = "0.1.0"
 dependencies = [
- "serde 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -21,6 +32,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "dtoa"
@@ -134,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -145,7 +173,7 @@ dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -157,6 +185,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "slab"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "term_size"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "time"
@@ -182,6 +223,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-segmentation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +240,11 @@ dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 authors = [""]
 
 [dependencies]
-ws = "0.5.1"
+clap = "2.11"
+mioco = "0.8"
+num_cpus = "1.0"
+scoped-pool = "1.0"
 serde = "0.8"
 serde_json = "0.8"
-clap = "2.11"
+threadpool = "1.0"
+ws = "0.5.1"

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -33,13 +33,11 @@ impl ws::Handler for BenchHandler {
 
     fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
         self.count += 1;
-        println!("Connection Open! {}", self.count);
         Ok(())
     }
 
     fn on_close(&mut self, _: ws::CloseCode, _: &str) {
         self.count -= 1;
-        println!("Connection Closed! {}", self.count);
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3,43 +3,10 @@ extern crate clap;
 extern crate serde;
 extern crate serde_json;
 
-use serde_json::Value;
-
 use clap::{App, Arg};
 
-const NULL_PAYLOAD: &'static Value = &Value::Null;
-
-struct BenchHandler {
-    ws: ws::Sender,
-    count: u32,
-}
-
-impl ws::Handler for BenchHandler {
-    fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
-        if let Ok(Ok(Value::Object(obj))) = msg.as_text().map(serde_json::from_str::<Value>) {
-            if let Some(&Value::String(ref s)) = obj.get("type") {
-                if s == "echo" {
-                    try!(self.ws.send(msg))
-                } else if s == "broadcast" {
-                    try!(self.ws.broadcast(msg));
-                    try!(self.ws.send(format!(r#"{{"type":"broadcastResult","listenCount": {},"payload":{}}}"#,
-                                              self.count,
-                                              obj.get("payload").unwrap_or(NULL_PAYLOAD))))
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
-        self.count += 1;
-        Ok(())
-    }
-
-    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
-        self.count -= 1;
-    }
-}
+mod single_threaded_ws;
+use single_threaded_ws::BenchHandler;
 
 fn main() {
     let matches = App::new("rust-ws-server")
@@ -59,17 +26,7 @@ fn main() {
                       .get_matches();
 
     if let (Some(address), Some(port)) = (matches.value_of("address"), matches.value_of("port")) {
-        ws::Builder::new()
-            .with_settings(ws::Settings { max_connections: 500_000, ..Default::default() })
-            .build(|out| {
-                BenchHandler {
-                    ws: out,
-                    count: 0,
-                }
-            })
-            .unwrap()
-            .listen(&*format!("{}:{}", address, port))
-            .unwrap();
+        BenchHandler::run(address, port);
     } else {
         println!("{}", matches.usage());
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,14 +1,23 @@
-extern crate ws;
 extern crate clap;
+extern crate mioco;
+extern crate num_cpus;
+extern crate scoped_pool;
 extern crate serde;
 extern crate serde_json;
+extern crate threadpool;
+extern crate ws;
 
-use clap::{App, Arg};
+use clap::{App, Arg, ArgGroup};
 
 mod single_threaded_ws;
-use single_threaded_ws::BenchHandler;
+mod mioco_ws;
+mod threadpool_ws;
+mod scopedpool_ws;
 
 fn main() {
+    // idea is 2 threads per core, but leave 1 for handling the ws connection itself
+    let default_threads = 2 * num_cpus::get() - 1;
+
     let matches = App::new("rust-ws-server")
                       .version("1.0")
                       .arg(Arg::with_name("address")
@@ -23,10 +32,37 @@ fn main() {
                                .required(true)
                                .takes_value(true)
                                .default_value("3000"))
-                      .get_matches();
+                      .arg(Arg::with_name("ws"))
+                      .arg(Arg::with_name("threadpool-ws"))
+                      .arg(Arg::with_name("scopedpool-ws"))
+                      .arg(Arg::with_name("mioco-ws"))
+                      .arg(Arg::with_name("threads")
+                            .short("t"))
+                      .group(ArgGroup::with_name("impls")
+                           .args(&["ws", "threadpool-ws", "scopedpool-ws", "mioco-ws"])
+                           .required(true)
+                           )
+                     .get_matches();
 
     if let (Some(address), Some(port)) = (matches.value_of("address"), matches.value_of("port")) {
-        BenchHandler::run(address, port);
+        let implementation = matches.value_of("impls").unwrap();
+        
+        match implementation {
+            "ws" => single_threaded_ws::BenchHandler::run(address, port),
+            "threadpool-ws" => {
+                let threads: usize = matches.value_of("threads").and_then(|t| t.parse().ok()).unwrap_or(default_threads);
+                threadpool_ws::BenchHandler::run(address, port, threads);
+            },
+            "scopedpool-ws" => {
+                let threads: usize = matches.value_of("threads").and_then(|t| t.parse().ok()).unwrap_or(default_threads);
+                scopedpool_ws::BenchHandler::run(address, port, threads);
+            },
+            "mioco-ws" => {
+                let threads: usize = matches.value_of("threads").and_then(|t| t.parse().ok()).unwrap_or(default_threads);
+                mioco_ws::BenchHandler::run(address, port, threads);
+            },
+            _ => unreachable!{}
+        }
     } else {
         println!("{}", matches.usage());
     }

--- a/rust/src/mioco_ws.rs
+++ b/rust/src/mioco_ws.rs
@@ -1,0 +1,72 @@
+use serde_json;
+use serde_json::Value;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use mioco;
+use ws;
+
+const NULL_PAYLOAD: &'static Value = &Value::Null;
+
+pub struct BenchHandler<'a> {
+    ws: ws::Sender,
+    count: &'a AtomicUsize,
+}
+
+impl<'a> BenchHandler<'a> {
+    pub fn run(address: &str, port: &str, threads: usize) {
+        let address = String::from(address);
+        let port = String::from(port);
+
+        mioco::start_threads(threads, move|| {
+            let count = AtomicUsize::new(0);
+
+            ws::Builder::new()
+                .with_settings(ws::Settings { max_connections: 500_000, ..Default::default() })
+                .build(|out| {
+                    BenchHandler {
+                        ws: out,
+                        count: &count,
+                    }
+                })
+                .unwrap()
+                .listen(&*format!("{}:{}", address, port))
+                .unwrap()
+                ;
+        }).unwrap();
+    }
+}
+
+impl<'a> ws::Handler for BenchHandler<'a> {
+    fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
+        // would love to not preload the atomic but the 'static bound
+        // on the execute function demands it :(
+        let ws = self.ws.clone();
+        let count = self.count.load(Ordering::SeqCst);
+
+        mioco::spawn(move|| {
+            if let Ok(Ok(Value::Object(obj))) = msg.as_text().map(serde_json::from_str::<Value>) {
+                if let Some(&Value::String(ref s)) = obj.get("type") {
+                    if s == "echo" {
+                        ws.send(msg).unwrap();
+                    } else if s == "broadcast" {
+                        ws.broadcast(msg).unwrap();
+                        ws.send(format!(r#"{{"type":"broadcastResult","listenCount": {},"payload":{}}}"#,
+                                                  count,
+                                                  obj.get("payload").unwrap_or(NULL_PAYLOAD))).unwrap();
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
+        self.count.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+

--- a/rust/src/scopedpool_ws.rs
+++ b/rust/src/scopedpool_ws.rs
@@ -1,0 +1,70 @@
+use serde_json;
+use serde_json::Value;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use scoped_pool as sp;
+use ws;
+
+const NULL_PAYLOAD: &'static Value = &Value::Null;
+
+pub struct BenchHandler<'a: 'b, 'b> {
+    ws: ws::Sender,
+    count: &'a AtomicUsize,
+    pool: &'b sp::Scope<'a>,
+}
+
+impl<'a, 'b> BenchHandler<'a, 'b> {
+    pub fn run(address: &str, port: &str, threads: usize) {
+        let count = AtomicUsize::new(0);
+        let pool = sp::Pool::new(threads);
+
+        pool.scoped(|scope| {
+            ws::Builder::new()
+                .with_settings(ws::Settings { max_connections: 500_000, ..Default::default() })
+                .build(|out| {
+                    BenchHandler {
+                        ws: out,
+                        count: &count,
+                        pool: scope,
+                    }
+                })
+                .unwrap()
+                .listen(&*format!("{}:{}", address, port))
+                .unwrap()
+                ;
+        });
+    }
+}
+
+impl<'a, 'b> ws::Handler for BenchHandler<'a, 'b> {
+    fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
+        let ws = self.ws.clone();
+        let count = self.count;
+
+        self.pool.execute(move|| {
+            if let Ok(Ok(Value::Object(obj))) = msg.as_text().map(serde_json::from_str::<Value>) {
+                if let Some(&Value::String(ref s)) = obj.get("type") {
+                    if s == "echo" {
+                        ws.send(msg).unwrap();
+                    } else if s == "broadcast" {
+                        ws.broadcast(msg).unwrap();
+                        ws.send(format!(r#"{{"type":"broadcastResult","listenCount": {},"payload":{}}}"#,
+                                                  count.load(Ordering::SeqCst),
+                                                  obj.get("payload").unwrap_or(NULL_PAYLOAD))).unwrap();
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
+        self.count.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+

--- a/rust/src/single_threaded_ws.rs
+++ b/rust/src/single_threaded_ws.rs
@@ -1,0 +1,56 @@
+use serde_json;
+use serde_json::Value;
+use ws;
+
+const NULL_PAYLOAD: &'static Value = &Value::Null;
+
+pub struct BenchHandler {
+    ws: ws::Sender,
+    count: u32,
+}
+
+impl BenchHandler {
+    pub fn run(address: &str, port: &str) {
+        ws::Builder::new()
+            .with_settings(ws::Settings { max_connections: 500_000, ..Default::default() })
+            .build(|out| {
+                BenchHandler {
+                    ws: out,
+                    count: 0,
+                }
+            })
+        .unwrap()
+        .listen(&*format!("{}:{}", address, port))
+        .unwrap()
+        ;
+    }
+}
+
+impl ws::Handler for BenchHandler {
+    fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
+        if let Ok(Ok(Value::Object(obj))) = msg.as_text().map(serde_json::from_str::<Value>) {
+            if let Some(&Value::String(ref s)) = obj.get("type") {
+                if s == "echo" {
+                    try!(self.ws.send(msg))
+                } else if s == "broadcast" {
+                    try!(self.ws.broadcast(msg));
+                    try!(self.ws.send(format!(r#"{{"type":"broadcastResult","listenCount": {},"payload":{}}}"#,
+                                              self.count,
+                                              obj.get("payload").unwrap_or(NULL_PAYLOAD))))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
+        self.count += 1;
+        Ok(())
+    }
+
+    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
+        self.count -= 1;
+    }
+}
+
+

--- a/rust/src/threadpool_ws.rs
+++ b/rust/src/threadpool_ws.rs
@@ -1,0 +1,70 @@
+use serde_json;
+use serde_json::Value;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use threadpool as tp;
+use ws;
+
+const NULL_PAYLOAD: &'static Value = &Value::Null;
+
+pub struct BenchHandler<'a> {
+    ws: ws::Sender,
+    count: &'a AtomicUsize,
+    pool: &'a tp::ThreadPool,
+}
+
+impl<'a> BenchHandler<'a> {
+    pub fn run(address: &str, port: &str, threads: usize) {
+        let count = AtomicUsize::new(0);
+        let pool = tp::ThreadPool::new(threads);
+
+        ws::Builder::new()
+            .with_settings(ws::Settings { max_connections: 500_000, ..Default::default() })
+            .build(|out| {
+                BenchHandler {
+                    ws: out,
+                    count: &count,
+                    pool: &pool,
+                }
+            })
+            .unwrap()
+            .listen(&*format!("{}:{}", address, port))
+            .unwrap()
+            ;
+    }
+}
+
+impl<'a> ws::Handler for BenchHandler<'a> {
+    fn on_message(&mut self, msg: ws::Message) -> ws::Result<()> {
+        // would love to not preload the atomic but the 'static bound
+        // on the execute function demands it :(
+        let ws = self.ws.clone();
+        let count = self.count.load(Ordering::SeqCst);
+
+        self.pool.execute(move|| {
+            if let Ok(Ok(Value::Object(obj))) = msg.as_text().map(serde_json::from_str::<Value>) {
+                if let Some(&Value::String(ref s)) = obj.get("type") {
+                    if s == "echo" {
+                        ws.send(msg).unwrap();
+                    } else if s == "broadcast" {
+                        ws.broadcast(msg).unwrap();
+                        ws.send(format!(r#"{{"type":"broadcastResult","listenCount": {},"payload":{}}}"#,
+                                                  count,
+                                                  obj.get("payload").unwrap_or(NULL_PAYLOAD))).unwrap();
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    fn on_open(&mut self, _: ws::Handshake) -> ws::Result<()> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn on_close(&mut self, _: ws::CloseCode, _: &str) {
+        self.count.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+


### PR DESCRIPTION
I've moved the basic single threaded implementation into its own module, and added several simple threaded implementations: mioco, scoped-pool, and threadpool.

The actual executable must now be run with an argument to choose which implementation to use. Options are "ws", "scopedpool-ws", "threadpool-ws", "mioco-ws". For example, `bin/rust-ws-server mioco-ws`. Threads can be tuned with a `--thread/-t` parameter.

All the variations run on my computer and use more than one CPU. I didn't really see much better performance but I suspect that's due to running _everything_ including the bencher locally. Maybe if they don't actually perform well someone else will take up the mantle of fixing them :).

Very interested to see how these compare when run in a more appropriate testing environment.
