### PR TITLE
Improve js clustering, ws impl, README

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.JS 4,5, or 6+
+- Node.JS 6+
 
 ## Build
 
@@ -26,4 +26,12 @@ Or, run the implementations in a cluster:
 node run-cluster.js uws
 ```
 
-`run-cluster.js` will spawn a process for each cpu core.
+By default, the cluster will spawn a worker process for each CPU (or cpu core).
+To specify the number of workers to spawn, provide the desired number to
+`run-cluster.js`:
+
+```bash
+node run-cluster.js uws 3
+```
+
+`run-cluster.js` will spawn 3 worker processes.

--- a/js/run-cluster.js
+++ b/js/run-cluster.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const impl = process.argv[2];
+const numProcs = +process.argv[3] ?
+  +process.argv[3] : require('os').cpus().length;
 
 if (!impl) {
   console.error('No implementation provided');
@@ -18,11 +20,10 @@ switch (impl) {
 }
 
 const cluster = require('cluster');
-const numCPUs = require('os').cpus().length;
 
 if (cluster.isMaster) {
   // Fork workers.
-  for (var i = 0; i < numCPUs; i++) {
+  for (var i = 0; i < numProcs; i++) {
     cluster.fork();
   }
 
@@ -44,7 +45,7 @@ if (cluster.isMaster) {
 
   cluster.on('message', (worker, msg) => {
     Object.keys(cluster.workers).forEach((id) => {
-      if (parseInt(id) !== worker.id) {
+      if (+id !== worker.id) {
         cluster.workers[id].send(msg);
       }
     });

--- a/js/ws/index.js
+++ b/js/ws/index.js
@@ -10,8 +10,9 @@ var wss = new ws.Server({
 
 if (cluster.isWorker) {
   process.on('message', function(msg) {
+    var msgBuf = Buffer(msg);
     wss.clients.forEach(function each(client) {
-      client.send(msg);
+      client.send(msgBuf);
     });
   });
 }
@@ -26,8 +27,10 @@ function broadcast(ws, payload) {
   if (cluster.isWorker) {
     process.send(msg);
   }
+
+  var msgBuf = Buffer(msg);
   wss.clients.forEach(function each(client) {
-    client.send(msg);
+    client.send(msgBuf);
   });
 
   ws.send(JSON.stringify({type: 'broadcastResult', payload: payload}));


### PR DESCRIPTION
- Remove note on Node 4,5 support
- Modify ws impl to create a `Buffer` before iterating over client
  sockets
- Add numProcs to run-cluster.js to allow user specified number of
  worker processes to be launched
- Use `+` to cast instead of `parseInt`
