### PR TITLE
Remove note about crashing from JRuby benchmark

### DIFF
--- a/results/round-02.md
+++ b/results/round-02.md
@@ -895,8 +895,6 @@ clients: 16000    95per-rtt: 497ms    min-rtt:  91ms    median-rtt: 226ms    max
 clients: 17000    95per-rtt: 459ms    min-rtt:  56ms    median-rtt: 254ms    max-rtt: 538ms
 ```
 
-* Note: Server crashes after benchmark runs.
-
 ## Rust - ws
 
 Server Environment


### PR DESCRIPTION
I believe the crash has been resolved in https://github.com/hashrocket/websocket-shootout/commit/d19e22f3cfae2e593086f92804aa1ca39861af86
