### PR TITLE
Add total-steps mode to websocket-bench

### DIFF
--- a/go/src/hashrocket/websocket-bench/benchmark/benchmark.go
+++ b/go/src/hashrocket/websocket-bench/benchmark/benchmark.go
@@ -30,6 +30,7 @@ type Config struct {
 	SampleSize         int
 	LimitPercentile    int
 	LimitRTT           time.Duration
+	TotalSteps         int
 	ClientPools        []ClientPool
 	ResultRecorder     ResultRecorder
 }
@@ -58,8 +59,11 @@ func (b *Benchmark) Run() error {
 		return err
 	}
 
+	stepNum := 0
+
 	for {
 
+		stepNum += 1
 		inProgress := 0
 		for i := 0; i < b.Concurrent; i++ {
 			if err := b.sendToRandomClient(); err != nil {
@@ -88,7 +92,7 @@ func (b *Benchmark) Run() error {
 
 		expectedRxBroadcastCount += len(b.clients) * b.SampleSize
 
-		if b.LimitRTT < rttAgg.Percentile(b.LimitPercentile) {
+		if (b.TotalSteps > 0 && b.TotalSteps == stepNum-1) || (b.TotalSteps == 0 && b.LimitRTT < rttAgg.Percentile(b.LimitPercentile)) {
 			if b.ClientCmd == ClientBroadcastCmd {
 				// Due to the async nature of the broadcasts and the receptions, it is
 				// possible for the broadcastResult to arrive before all the

--- a/go/src/hashrocket/websocket-bench/cmd/websocket-bench/main.go
+++ b/go/src/hashrocket/websocket-bench/cmd/websocket-bench/main.go
@@ -24,6 +24,7 @@ var options struct {
 	workerListenAddr   string
 	workerListenPort   int
 	workerAddrs        []string
+	totalSteps         int
 }
 
 func main() {
@@ -46,6 +47,7 @@ func main() {
 	cmdEcho.Flags().IntVarP(&options.limitPercentile, "limit-percentile", "", 95, "round-trip time percentile to for limit")
 	cmdEcho.Flags().IntVarP(&options.payloadPaddingSize, "payload-padding", "", 0, "payload padding size")
 	cmdEcho.Flags().DurationVarP(&options.limitRTT, "limit-rtt", "", time.Millisecond*500, "Max RTT at limit percentile")
+	cmdEcho.Flags().IntVarP(&options.totalSteps, "total-steps", "", 0, "Run benchmark for specified number of steps")
 	rootCmd.AddCommand(cmdEcho)
 
 	cmdBroadcast := &cobra.Command{
@@ -65,6 +67,7 @@ func main() {
 	cmdBroadcast.Flags().IntVarP(&options.limitPercentile, "limit-percentile", "", 95, "round-trip time percentile to for limit")
 	cmdBroadcast.Flags().IntVarP(&options.payloadPaddingSize, "payload-padding", "", 0, "payload padding size")
 	cmdBroadcast.Flags().DurationVarP(&options.limitRTT, "limit-rtt", "", time.Millisecond*500, "Max RTT at limit percentile")
+	cmdBroadcast.Flags().IntVarP(&options.totalSteps, "total-steps", "", 0, "Run benchmark for specified number of steps")
 	rootCmd.AddCommand(cmdBroadcast)
 
 	cmdWorker := &cobra.Command{
@@ -105,6 +108,7 @@ func Stress(cmd *cobra.Command, args []string) {
 	config.InitialClients = options.initialClients
 	config.LimitPercentile = options.limitPercentile
 	config.LimitRTT = options.limitRTT
+	config.TotalSteps = options.totalSteps
 	config.ResultRecorder = benchmark.NewTextResultRecorder(os.Stdout)
 
 	localAddrs := parseTCPAddrs(options.localAddrs)


### PR DESCRIPTION
This PR adds an alternative mode for benchmarking: running fixed number of _steps_.

Usage:

```
bin/websocket-bench broadcast ws://0.0.0.0:3334/cable -c 10 -s 10 --step-size 100 --total-steps 10
```