### PR TITLE
Update application due to API and design changes

### DIFF
--- a/ruby/plezi-iodine/config.ru
+++ b/ruby/plezi-iodine/config.ru
@@ -1,5 +1,7 @@
 # # Plezi Rack Application file.
-
+# #
+# # Written for Plezi v.0.15 with Iodine v.0.4
+# #
 # # NOTE: Plezi requires `iodine` for Websocket support.
 # #       No Iodine, no websockets.
 
@@ -8,28 +10,42 @@
 # # i.e.:
 # iodine -t 8 -p 3334
 
-
+# local process cluster support is built into iodine's pub/sub, but cross machine pub/sub requires Redis.
 require 'plezi'
 
 class ShootoutApp
-  # the default HTTP response
+
   def index
     "This application should be used with the websocket-shootout benchmark utility."
   end
-  # we won't be using AutoDispatch, but directly using the `on_message` callback.
+  
+  def on_open
+    subscribe channel: "shootout"
+  end
+
   def on_message data
+
+    if data[0] == 'b' # binary
+      publish(channel: "shootout", message: data)
+      data[0] = 'r'
+      write data
+      return
+    end
+
     cmd, payload = JSON(data).values_at('type', 'payload')
     if cmd == 'echo'
       write({type: 'echo', payload: payload}.to_json)
     else
-      ShootoutApp.broadcast :_send_payload, {type: 'broadcast', payload: payload}.to_json
+      # data = {type: 'broadcast', payload: payload}.to_json
+      # broadcast :push2client, data
+      publish(channel: "shootout", message: ({type: 'broadcast', payload: payload}.to_json))
       write({type: "broadcastResult", payload: payload}.to_json)
     end
+
+  rescue
+    puts "Incoming message format error!"
   end
-  # send the actual data. This will be invoked by Plezi's broadcast.
-  def _send_payload payload
-    write payload
-  end
+
 end
 
 Plezi.route '*', ShootoutApp


### PR DESCRIPTION
This benchmark uses iodine's built-in Pub/Sub, which is more representative of a real-life application than the previous benchmark application (publishing to channels and checking web socket subscriptions is more likely than an all-out websocket broadcasting to all clients).

Also, the previous application was using API calls that were deprecated in Plezi's and iodine's latest versions.

I didn't update the `gemfile.lock`, since I'm pushing this through the Github website... sorry about that.

Thanks!