### PR TITLE
Fixing uws dependancy in JS impl

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "bufferutil": "^3.0.0",
     "faye-websocket": "^0.11.0",
-    "uws": "^0.10.0",
+    "uws": "^0.14.5",
     "ws": "^2.2.2"
   }
 }


### PR DESCRIPTION
Looks like uws version used was unpublished, see https://github.com/npm/npm/issues/16178

` npm show uws versions`
> [ '0.14.1',
>   '0.14.3',
>   '0.14.4',
>   '0.14.5',
>   '8.14.0',
>   '8.14.1',
>   '9.14.0' ]
> 

Error on install:

> npm ERR! notarget No matching version found for uws@^0.10.0
> npm ERR! notarget In most cases you or one of your dependencies are requesting
> npm ERR! notarget a package version that doesn't exist.
> npm ERR! notarget
> npm ERR! notarget It was specified as a dependency of 'ws-bench'
> npm ERR! notarget