### PR TITLE
Atomics instead of Mutex

### DIFF
--- a/go/src/hashrocket/websocket-bench/benchmark/local_client.go
+++ b/go/src/hashrocket/websocket-bench/benchmark/local_client.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/net/websocket"
@@ -31,7 +32,7 @@ type localClient struct {
 	payloadPadding []byte
 
 	rxBroadcastCountLock sync.Mutex
-	rxBroadcastCount     int
+	rxBroadcastCount     int64
 }
 
 type ServerAdapter interface {
@@ -151,10 +152,7 @@ func (c *localClient) SendBroadcast() error {
 }
 
 func (c *localClient) ResetRxBroadcastCount() (int, error) {
-	c.rxBroadcastCountLock.Lock()
-	count := c.rxBroadcastCount
-	c.rxBroadcastCount = 0
-	c.rxBroadcastCountLock.Unlock()
+	count := int(atomic.SwapInt64(&c.rxBroadcastCount, 0))
 	return count, nil
 }
 
@@ -165,7 +163,6 @@ func (c *localClient) rx() {
 			c.errChan <- err
 			return
 		}
-
 		switch msg.Type {
 		case MsgServerEcho, MsgServerBroadcastResult:
 			if msg.Payload != nil {
@@ -176,9 +173,7 @@ func (c *localClient) rx() {
 				return
 			}
 		case MsgServerBroadcast:
-			c.rxBroadcastCountLock.Lock()
-			c.rxBroadcastCount++
-			c.rxBroadcastCountLock.Unlock()
+			atomic.AddInt64(&c.rxBroadcastCount, 1)
 		default:
 			c.errChan <- fmt.Errorf("received unknown message type: %v", msg.Type)
 			return

--- a/go/src/hashrocket/websocket-bench/benchmark/local_client.go
+++ b/go/src/hashrocket/websocket-bench/benchmark/local_client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,8 +30,7 @@ type localClient struct {
 	errChan        chan<- error
 	payloadPadding []byte
 
-	rxBroadcastCountLock sync.Mutex
-	rxBroadcastCount     int64
+	rxBroadcastCount int64
 }
 
 type ServerAdapter interface {


### PR DESCRIPTION
By using atomics instead of a mutex the benchmark took overhead is decreased a little. I saw slightly better  results using atomics. The difference may have been within statistical errors though. The first attempt with the change was 15% faster but subsequence runs were similar to with mutex. Anyway, fewer lines of code if you care.